### PR TITLE
URL Cleanup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -446,7 +446,7 @@ STS PARENT POM
 					<storepass>${signing.store.password}</storepass>
 					<keypass>${signing.key.password}</keypass>
 <!--					<tsa>https://ca.signfiles.com/tsa/get.aspx</tsa> -->
-					<tsa>http://sha256timestamp.ws.symantec.com/sha256/timestamp</tsa>
+					<tsa>https://sha256timestamp.ws.symantec.com/sha256/timestamp</tsa>
 				</configuration>
 			</plugin>
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://sha256timestamp.ws.symantec.com/sha256/timestamp (InvalidMediaTypeException) with 1 occurrences migrated to:  
  https://sha256timestamp.ws.symantec.com/sha256/timestamp ([https](https://sha256timestamp.ws.symantec.com/sha256/timestamp) result ConnectTimeoutException).

# Ignored
These URLs were intentionally ignored.

* http://java.sun.com/xml/ns/javaee with 2 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 1 occurrences